### PR TITLE
SP-715 Use the build module since we no longer need setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,7 @@ jobs:
           pipenv run mypy -p src
       - name: Run unit tests
         run: pipenv run pytest -vv -s -m unit
+      - name: Run a test build
+        run: |
+          pipenv run pip3 install --upgrade build
+          pipenv run python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           python-version: 3.8
       - run: |
-          python setup.py sdist
+          python -m pip install --upgrade build
+          python -m build
       - uses: actions/upload-artifact@v3
         with:
           path: ./dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.8
       - run: |
-          python -m pip install --upgrade build
+          pip3 install --upgrade build
           python -m build
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Since we no longer have or need `setup.py`, I'm doing the following:

1. Installing the `build` module
2. Running `python -m build`

This creates a package with the same structure as `python setup.py sdist`.