### PR TITLE
SP-893 Fix Python POS client creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bitpay"
-version = "6.0.0"
+version = "6.0.1"
 authors = [
   { name="Antonio Buedo", email="sales-engineering@bitpay.com" },
 ]

--- a/src/bitpay/client.py
+++ b/src/bitpay/client.py
@@ -61,11 +61,11 @@ class Client:
             )
 
     @staticmethod
-    def create_pos_client(self, pos_token: str, environment: Environment = Environment.PROD):  # type: ignore
+    def create_pos_client(pos_token: str, environment: Environment = Environment.PROD):  # type: ignore
         token_container = TokenContainer()
         token_container.add_pos(pos_token)
 
-        bitpay_client = BitPayClient(self.get_base_url(environment))
+        bitpay_client = BitPayClient(Client.get_base_url(environment))
 
         return Client(bitpay_client, token_container, GuidGenerator())
 

--- a/src/bitpay/config.py
+++ b/src/bitpay/config.py
@@ -5,6 +5,6 @@ class Config(Enum):
     TEST_URL = "https://test.bitpay.com/"
     PROD_URL = "https://bitpay.com/"
     BITPAY_API_VERSION = "2.0.0"
-    BITPAY_PLUGIN_INFO = "BitPay_Python_Client_v6.0.0"
+    BITPAY_PLUGIN_INFO = "BitPay_Python_Client_v6.0.1"
     BITPAY_API_FRAME = "std"
     BITPAY_API_FRAME_VERSION = "1.0.0"


### PR DESCRIPTION
# Overview

The goal of this PR is to allow a POS client to be created with either `create_client()` or `create_pos_client()`. Currently, passing in a config to `create_client()` will work, but this PR makes it easier to use `create_pos_client()` directly by passing a POS token.