### PR TITLE
Fix satoshisPerByte and remove '.value' from examples

### DIFF
--- a/examples/Pos/bill_requests.py
+++ b/examples/Pos/bill_requests.py
@@ -6,7 +6,7 @@ from bitpay.models.facade import Facade
 
 class BillRequests:
     def create_bill(self) -> None:
-        client = Client.create_pos_client('somePosToken', Environment.TEST.value)
+        client = Client.create_pos_client('somePosToken', Environment.TEST)
 
         bill = Bill()
         bill.name = 'someName'
@@ -18,11 +18,11 @@ class BillRequests:
         result = client.create_bill(bill, Facade.POS, False)
 
     def get_bill(self) -> None:
-        client = Client.create_pos_client('somePosToken', Environment.TEST.value)
+        client = Client.create_pos_client('somePosToken', Environment.TEST)
 
         result = client.get_bill('someBillId', Facade.POS, False)
 
     def deliver_bill_via_email(self) -> None:
-        client = Client.create_pos_client('somePosToken', Environment.TEST.value)
+        client = Client.create_pos_client('somePosToken', Environment.TEST)
 
         result = client.deliver_bill('someBillId', 'token')

--- a/examples/Pos/invoice_requests.py
+++ b/examples/Pos/invoice_requests.py
@@ -27,11 +27,11 @@ class InvoiceRequests:
 
         invoice.buyer = buyer
 
-        client = Client.create_pos_client('somePosToken', Environment.TEST.value)
+        client = Client.create_pos_client('somePosToken', Environment.TEST)
 
         result = client.create_invoice(invoice, Facade.POS, False)
 
     def get_invoice(self) -> None:
-        client = Client.create_pos_client('somePosToken', Environment.TEST.value)
+        client = Client.create_pos_client('somePosToken', Environment.TEST)
 
         invoice_by_id = client.get_invoice('someInvoiceId', Facade.POS, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bitpay"
-version = "6.0.1"
+version = "6.0.2"
 authors = [
   { name="Antonio Buedo", email="sales-engineering@bitpay.com" },
 ]

--- a/src/bitpay/config.py
+++ b/src/bitpay/config.py
@@ -5,6 +5,6 @@ class Config(Enum):
     TEST_URL = "https://test.bitpay.com/"
     PROD_URL = "https://bitpay.com/"
     BITPAY_API_VERSION = "2.0.0"
-    BITPAY_PLUGIN_INFO = "BitPay_Python_Client_v6.0.1"
+    BITPAY_PLUGIN_INFO = "BitPay_Python_Client_v6.0.2"
     BITPAY_API_FRAME = "std"
     BITPAY_API_FRAME_VERSION = "1.0.0"

--- a/src/bitpay/models/invoice/miner_fees_item.py
+++ b/src/bitpay/models/invoice/miner_fees_item.py
@@ -15,6 +15,6 @@ class MinerFeesItem(BitPayModel):
     see this support article for more information
     """
 
-    satoshis_per_byte: Union[int, None] = None
+    satoshis_per_byte: Union[float, None] = None
     total_fee: Union[int, None] = None
     fiat_amount: Union[float, None] = None

--- a/tests/unit/models/invoice/test_miner_fees_item.py
+++ b/tests/unit/models/invoice/test_miner_fees_item.py
@@ -6,10 +6,10 @@ from bitpay.models.invoice.miner_fees_item import MinerFeesItem
 @pytest.mark.unit
 def test_constructor():
     amount = 12.34
-    satoshis = 12345
+    satoshis = 12.345
     total_fee = 4354
     miner_fees_item = MinerFeesItem(fiat_amount=amount, satoshis_per_byte=satoshis, total_fee=total_fee)
 
     assert amount == miner_fees_item.fiat_amount
-    assert 12345 == miner_fees_item.satoshis_per_byte
+    assert 12.345 == miner_fees_item.satoshis_per_byte
     assert total_fee == miner_fees_item.total_fee


### PR DESCRIPTION
## Overview

This PR has two changes:
* Fixing type on `satoshisPerByte`
* Updating examples

### Fixing type on satoshisPerByte

This is a new field that was defined as an `int` but needed to be updated to a `float`. I've tested this in a small project by pointing my `pipfile` to my branch.

### Updating Examples
Our examples had:

```python
client = Client.create_pos_client('somePosToken', Environment.TEST)
```

But that will throw an exception, so I've updated to:

```python
client = Client.create_pos_client('somePosToken', Environment.TEST.value)
```