### PR TITLE
SP-943 Python SDK should handle scientific notation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bitpay"
-version = "6.0.2"
+version = "6.0.3"
 authors = [
   { name="Antonio Buedo", email="sales-engineering@bitpay.com" },
 ]

--- a/src/bitpay/config.py
+++ b/src/bitpay/config.py
@@ -5,6 +5,6 @@ class Config(Enum):
     TEST_URL = "https://test.bitpay.com/"
     PROD_URL = "https://bitpay.com/"
     BITPAY_API_VERSION = "2.0.0"
-    BITPAY_PLUGIN_INFO = "BitPay_Python_Client_v6.0.2"
+    BITPAY_PLUGIN_INFO = "BitPay_Python_Client_v6.0.3"
     BITPAY_API_FRAME = "std"
     BITPAY_API_FRAME_VERSION = "1.0.0"

--- a/src/bitpay/models/invoice/invoice.py
+++ b/src/bitpay/models/invoice/invoice.py
@@ -1,6 +1,7 @@
 """
 Invoice
 """
+
 from decimal import *
 from typing import List, Union, Dict
 from pydantic import Field

--- a/src/bitpay/models/invoice/invoice.py
+++ b/src/bitpay/models/invoice/invoice.py
@@ -1,7 +1,7 @@
 """
 Invoice
 """
-
+from decimal import *
 from typing import List, Union, Dict
 from pydantic import Field
 from .buyer import Buyer
@@ -41,8 +41,8 @@ class Invoice(BitPayModel):
     item_code: Union[str, None] = None
     physical: Union[bool, None] = False
     payment_currencies: Union[List[str], None] = None
-    payment_subtotals: Union[Dict[str, int], None] = None
-    payment_totals: Union[Dict[str, int], None] = None
+    payment_subtotals: Union[Dict[str, Decimal], None] = None
+    payment_totals: Union[Dict[str, Decimal], None] = None
     payment_display_totals: Union[Dict[str, str], None] = None
     payment_display_subtotals: Union[Dict[str, str], None] = None
     payment_codes: Union[Dict[str, Dict[str, str]], None] = None

--- a/src/bitpay/models/invoice/invoice_webhook.py
+++ b/src/bitpay/models/invoice/invoice_webhook.py
@@ -1,3 +1,4 @@
+from decimal import *
 from typing import Union, Dict
 
 from bitpay.models.bitpay_model import BitPayModel
@@ -14,8 +15,8 @@ class InvoiceWebhook(BitPayModel):
     id: Union[str, None] = None
     invoice_time: Union[str, None] = None
     order_id: Union[str, None] = None
-    payment_subtotals: Union[Dict[str, int], None] = None
-    payment_totals: Union[Dict[str, int], None] = None
+    payment_subtotals: Union[Dict[str, Decimal], None] = None
+    payment_totals: Union[Dict[str, Decimal], None] = None
     pos_data: Union[str, None] = None
     price: Union[float, None] = None
     status: Union[str, None] = None


### PR DESCRIPTION
## Overview

As reported by [DorskFR](https://github.com/DorskFR) on #110, we can sometimes have values for `paymentTotals.*` and `paymentSubtotals.*` can come back as scientific notation, for example:

```jsonc
...
"paymentSubtotals": {
  "BTC": 1394587,
  "BCH": 200349400,
  "ETH": 298189000000000000,
  "GUSD": 86000,
  "PAX": 860000000000000000000,
  "BUSD": 860000000000000000000,
  "USDC": 860000000,
  "DOGE": 586597875600,
  "LTC": 1089539700,
  "MATIC": 1.321044547e+21,
  "USDC_m": 860000000,
  "USDT": 860410000,
  "USDT_m": 860410000,
  "PYUSD": 860000000,
  "USDCn_m": 860000000
}
...
```

Scientific notation values such as `1.321044547e+21` while uncommon are valid in JSON per [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf):
> A number is a sequence of decimal digits with no superfluous leading zero. It may have a preceding minus
sign (U+002D). It may have a fractional part prefixed by a decimal point (U+002E). It may have an exponent,
prefixed by e (U+0065) or E (U+0045) and optionally + (U+002B) or – (U+002D). The digits are the code
points U+0030 through U+0039.

The number `1.321044547e+21` is valid Python as well, however it is too large for an `int`, so we need to define these fields as a `Decimal` type from the `decimal` library.

## Changes

- Import the `decimal` library 
- Use the `Decimal` type instead of `int`

## Notes

Testing shows that this is not required for 5.0.x as these were being defined as `None`.