### PR TITLE
Security: Fix untrusted input vulnerability in release workflow - 7.0.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,14 @@ jobs:
     steps:
       - name: Extract release data
         id: release
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          echo "title=${{ github.event.release.name }}" >> $GITHUB_OUTPUT
+          echo "title=$RELEASE_NAME" >> $GITHUB_OUTPUT
           {
             echo "body<<EOF"
-            echo "${{ github.event.release.body }}"
+            echo "$RELEASE_BODY"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
@@ -56,9 +59,11 @@ jobs:
       - name: Publish changelog to Readme
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
+          RELEASE_TITLE: ${{ steps.release.outputs.title }}
+          RELEASE_BODY: ${{ steps.release.outputs.body }}
         run: |
-          jq -n --arg title "Python Unified SDK ${{ steps.release.outputs.title }}" \
-                --arg body "${{ steps.release.outputs.body }}" \
+          jq -n --arg title "Python Unified SDK $RELEASE_TITLE" \
+                --arg body "$RELEASE_BODY" \
                 '{
                   title: $title,
                   content: {


### PR DESCRIPTION
## Security Fix: Prevent Command Injection in Release Workflow

### Summary
This PR fixes a command injection vulnerability in the GitHub Actions release workflow by moving all untrusted inputs and GitHub context variables to environment variables.

### Problem
The workflow was directly interpolating user inputs and GitHub context variables into shell commands, which could allow command injection attacks. Specifically:

- `${{ github.event.release.name }}` - GitHub context variable
- `${{ github.event.release.body }}` - GitHub context variable
- `${{ steps.release.outputs.title }}` - Step output used in shell commands
- `${{ steps.release.outputs.body }}` - Step output used in shell commands

### Solution
All potentially untrusted values are now passed through environment variables before being used in shell commands. This ensures they are treated as literal strings rather than being evaluated as code.

**Changes made:**
1. **Extract release data step**: Added `RELEASE_NAME` and `RELEASE_BODY` environment variables to safely capture untrusted input
2. **Publish changelog step**: Added `RELEASE_TITLE` and `RELEASE_BODY` environment variables to safely pass step outputs

### Security Impact
This follows the security best practices outlined in the [GitHub Security Lab advisory](https://securitylab.github.com/resources/github-actions-untrusted-input/) and prevents potential command injection through GitHub Actions expressions.

### Testing
- [ ] Workflow syntax is valid
- [ ] No functional changes to workflow behavior
- [ ] All steps continue to work as expected